### PR TITLE
Initialize playerPoints before starting the game

### DIFF
--- a/drooms-game-impl/src/main/java/org/drooms/impl/GameController.java
+++ b/drooms-game-impl/src/main/java/org/drooms/impl/GameController.java
@@ -252,6 +252,7 @@ public abstract class GameController implements Game {
             pos.push(startingPositions.get(i));
             this.setPlayerPosition(player, pos);
             this.setPlayerLength(player, wormLength);
+            playerPoints.put(player, 0);
             GameController.LOGGER.info("Player {} assigned position {}.", player.getName(), i);
             i++;
         }
@@ -357,9 +358,6 @@ public abstract class GameController implements Game {
     }
 
     private void reward(final Player p, final int points) {
-        if (!this.playerPoints.containsKey(p)) {
-            this.playerPoints.put(p, 0);
-        }
         this.playerPoints.put(p, this.playerPoints.get(p) + points);
     }
 


### PR DESCRIPTION
Initializes the playerPoints eagerly instead of lazily. This way even if the player does not earn any point, he is mentioned in the end and in returned results (although with 0 points).
